### PR TITLE
Clarify rate limit messaging for users

### DIFF
--- a/.cursor/rules/notes.mdc
+++ b/.cursor/rules/notes.mdc
@@ -2,3 +2,4 @@
 [user-feedback] GitHub: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
 [error-fix] Changed "Rate Limited" → info icon hover with explanatory text
 [design] Removed redundant plan type display (already in user info section)
+[best-practice] UI messaging: avoid ambiguous terms, use progressive disclosure, eliminate redundancy

--- a/.cursor/rules/notes.mdc
+++ b/.cursor/rules/notes.mdc
@@ -1,0 +1,4 @@
+[ux] Rate limit tooltip message confusing - users unsure if "Rate Limited" means current status or plan type (<120 chars)
+[design] "Unlimited Requests | Rate Limited" messaging ambiguous - should clarify plan type vs current status
+[user-feedback] GitHub feedback: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
+[error-fix] Changed "Rate Limited" to "Pro Plan" and improved explanatory text to clarify plan type vs status

--- a/.cursor/rules/notes.mdc
+++ b/.cursor/rules/notes.mdc
@@ -2,3 +2,4 @@
 [design] "Unlimited Requests | Rate Limited" messaging ambiguous - should clarify plan type vs current status
 [user-feedback] GitHub feedback: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
 [error-fix] Changed "Rate Limited" to "Pro Plan" and improved explanatory text to clarify plan type vs status
+[optimization] Replaced second line with info icon hover - cleaner UI while preserving information accessibility

--- a/.cursor/rules/notes.mdc
+++ b/.cursor/rules/notes.mdc
@@ -3,3 +3,4 @@
 [user-feedback] GitHub feedback: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
 [error-fix] Changed "Rate Limited" to "Pro Plan" and improved explanatory text to clarify plan type vs status
 [optimization] Replaced second line with info icon hover - cleaner UI while preserving information accessibility
+[design] Removed redundant "Pro Plan" text since plan type already shown in user info section

--- a/.cursor/rules/notes.mdc
+++ b/.cursor/rules/notes.mdc
@@ -1,6 +1,4 @@
-[ux] Rate limit tooltip message confusing - users unsure if "Rate Limited" means current status or plan type (<120 chars)
-[design] "Unlimited Requests | Rate Limited" messaging ambiguous - should clarify plan type vs current status
-[user-feedback] GitHub feedback: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
-[error-fix] Changed "Rate Limited" to "Pro Plan" and improved explanatory text to clarify plan type vs status
-[optimization] Replaced second line with info icon hover - cleaner UI while preserving information accessibility
-[design] Removed redundant "Pro Plan" text since plan type already shown in user info section
+[ux] "Rate Limited" status vs plan type confusion - users unsure of current state vs plan capability
+[user-feedback] GitHub: "Does it mean I am being Rate Limited right now, or I am on the Rate Limit Plan?"
+[error-fix] Changed "Rate Limited" → info icon hover with explanatory text
+[design] Removed redundant plan type display (already in user info section)

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -322,7 +322,7 @@ export class StatusBarProvider {
       // Show unlimited status section for new pricing users
       log.debug(`[StatusBar] Showing unlimited requests section for new pricing`);
       tooltip.appendMarkdown(
-        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>Pro Plan</strong>&nbsp;<span title="Requests are rate limited based on your plan tier">$(info)</span></div>\n\n`,
+        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;<span title="Requests are rate limited based on your plan tier">$(info)</span></div>\n\n`,
       );
     }
 

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -322,7 +322,7 @@ export class StatusBarProvider {
       // Show unlimited status section for new pricing users
       log.debug(`[StatusBar] Showing unlimited requests section for new pricing`);
       tooltip.appendMarkdown(
-        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>Rate Limited</strong><br/>&nbsp;&nbsp;&nbsp;&nbsp;<small style="font-size:10px;opacity:0.8;line-height:0.9;">$(info) Rate limited based on your plan</small></div>\n\n`,
+        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>Pro Plan</strong><br/>&nbsp;&nbsp;&nbsp;&nbsp;<small style="font-size:10px;opacity:0.8;line-height:0.9;">$(info) Requests are rate limited based on your plan tier</small></div>\n\n`,
       );
     }
 

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -322,7 +322,7 @@ export class StatusBarProvider {
       // Show unlimited status section for new pricing users
       log.debug(`[StatusBar] Showing unlimited requests section for new pricing`);
       tooltip.appendMarkdown(
-        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>Pro Plan</strong><br/>&nbsp;&nbsp;&nbsp;&nbsp;<small style="font-size:10px;opacity:0.8;line-height:0.9;">$(info) Requests are rate limited based on your plan tier</small></div>\n\n`,
+        `<div style="padding:10px"><b>$(infinity) Unlimited Requests</b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<strong>Pro Plan</strong>&nbsp;<span title="Requests are rate limited based on your plan tier">$(info)</span></div>\n\n`,
       );
     }
 


### PR DESCRIPTION
The status bar display for new pricing model users in `src/ui/statusBar.ts` was refined to improve clarity and reduce redundancy.

Initially, the message "Rate Limited based on your plan" caused confusion, as it was unclear if it referred to a current status or plan type.

*   The message was first updated to "Pro Plan" with a descriptive second line: "Requests are rate limited based on your plan tier" to clarify it referred to the plan.
*   This second line was then removed to declutter the UI. An `$(info)` icon was added next to "Unlimited Requests", providing the detailed explanation "Requests are rate limited based on your plan tier" on hover. This implements progressive disclosure.
*   Finally, "Pro Plan" was removed from the status bar entirely. The plan type is already displayed in the user info section, making its repetition redundant.

The final display in `src/ui/statusBar.ts` shows `$(infinity) Unlimited Requests $(info)`, with the `$(info)` icon providing the necessary details on hover, ensuring a clean, non-redundant, and unambiguous user experience.